### PR TITLE
Save polygons to GROOPS file format

### DIFF
--- a/groopsio/io.py
+++ b/groopsio/io.py
@@ -782,7 +782,7 @@ def loadpolygon(fname):
 
 def savepolygon(fname, polygons):
     """
-    Read  a polygon list from file.
+    Save a polygon list to file.
 
     Parameters
     ----------

--- a/groopsio/io.py
+++ b/groopsio/io.py
@@ -780,6 +780,34 @@ def loadpolygon(fname):
     return giocpp.loadpolygon(fname)
 
 
+def savepolygon(fname, polygons):
+    """
+    Read  a polygon list from file.
+
+    Parameters
+    ----------
+    fname : str
+        file name
+    polygons : array_like(p, 2) or tuple of array_likes(p, 2)
+        tuple of 2-d arrays representing the vertices (longitude, latitude) of each polygon in radians.
+
+    Raises
+    ------
+    FileNotFoundError
+        if directory is not writeable
+    """
+    if split(fname)[0] and not isdir(split(fname)[0]):
+        raise FileNotFoundError('Directory ' + split(fname)[0] + ' does not exist.')
+
+    if type(polygons) is list:
+        polygons = tuple(polygons)
+
+    if type(polygons) is not tuple:
+        polygons = (polygons,)
+
+    return giocpp.savepolygon(fname, polygons)
+
+
 def loadparameternames(fname, encoding='utf-8', errors='strict'):
     """
     Read a parameter name list from file.

--- a/src/groopsio.cpp
+++ b/src/groopsio.cpp
@@ -46,6 +46,7 @@ extern "C" {
     {"savenormals", (PyCFunction)savenormals, METH_VARARGS, ""},
 
     {"loadpolygon", (PyCFunction)loadpolygon, METH_VARARGS, ""},
+    {"savepolygon", (PyCFunction)savepolygon, METH_VARARGS, ""},
 
     {NULL, NULL, 0, NULL}
   };

--- a/src/groopsio.h
+++ b/src/groopsio.h
@@ -825,7 +825,39 @@ static PyObject* loadpolygon(PyObject* /*self*/, PyObject* args)
 }
 
 /*
- * Read a GROOPS polygon list from file.
+ * Save a GROOPS polygon list to file.
+ */
+static PyObject* savepolygon(PyObject* /*self*/, PyObject* args)
+{
+  try
+  {
+    const char *s;
+    PyObject *list;
+    if(!PyArg_ParseTuple(args, "sO", &s, &list))
+      throw(Exception("Unable to parse arguments."));
+
+    UInt count = PyTuple_Size(list);
+    std::vector<Polygon> poly(count);
+    for(UInt k = 0; k < poly.size(); k++)
+    {
+      Matrix M = fromPyObject(PyTuple_GetItem(list, k));
+      poly.at(k).L = M.column(0);
+      poly.at(k).B = M.column(1);
+    }
+
+    writeFilePolygon(FileName(std::string(s)), poly);
+
+    Py_RETURN_NONE;
+  }
+  catch(std::exception& e)
+  {
+    PyErr_SetString(groopsError, e.what());
+    return NULL;
+  }
+}
+
+/*
+ * Read GROOPS parameter names from file.
  */
 static PyObject* loadparameternames(PyObject* /*self*/, PyObject* args)
 {


### PR DESCRIPTION
Added a function that saves a single polygon or a list of polygons to the corresponding GROOPS file format. A polygon list is represented by a container (tuple, list) of 2-dimensional NumPy ndarrays where array[:, 0] and array[:, 1] contains the longitude and latitude of the polygon vertices in radians. 